### PR TITLE
Bump version to override broken one in YolaPI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # [Changelog](https://github.com/yola/healthcheck)
 
+## 0.0.2
+* New version to override broken one in YolaPI.
+
 ## 0.0.1
 * First version. Ability to add HealthChecks for Yola Services.

--- a/healthcheck/__init__.py
+++ b/healthcheck/__init__.py
@@ -1,5 +1,5 @@
 __doc__ = 'Health Checker for Yola Services'
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 __url__ = 'https://github.com/yola/healthcheck'
 
 


### PR DESCRIPTION
The healthcheck artifacts in YolaPI are broken.  Increasing version to upload new artifacts.
