### PR TITLE
Fix double json encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /virtualenv.tar.gz
 .eggs/
 healthcheck.egg-info/
-.idea/
 
 # Ignore data directory (used for persistent files)
 /data

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /virtualenv.tar.gz
 .eggs/
 healthcheck.egg-info/
+.idea/
 
 # Ignore data directory (used for persistent files)
 /data

--- a/healthcheck/contrib/django/status_endpoint/tests/test_views.py
+++ b/healthcheck/contrib/django/status_endpoint/tests/test_views.py
@@ -68,3 +68,29 @@ class StatusEndpointViewsTestCase(TestCase):
         }
 
         self.assertEqual(response, expected_response)
+
+    @override_settings(
+        STATUS_CHECK_DBS=False,
+        STATUS_CHECK_FILES=('/usr/bin/env',)
+    )
+    def test_failed_check(self):
+        request = self.factory.get(reverse(views.status))
+        response = views.status(request)
+        response = {
+            'content': json.loads(response.content),
+            'status': response.status_code,
+        }
+
+        expected_response = {
+            'content': {
+                "quiesce file doesn't exist": {
+                    'details': {
+                        '/usr/bin/env': 'FILE EXISTS'
+                    },
+                    'status': 'FAILED'
+                }
+            },
+            'status': 500,
+        }
+
+        self.assertEqual(response, expected_response)

--- a/healthcheck/contrib/django/status_endpoint/views.py
+++ b/healthcheck/contrib/django/status_endpoint/views.py
@@ -37,6 +37,6 @@ def status(request):
         details = 'There were no checks.'
 
     if not ok:
-        return JsonResponseServerError(json.dumps(details))
+        return JsonResponseServerError(details)
 
     return JsonResponse(details)


### PR DESCRIPTION
Error responses were coming back looking like:
`"{\"Django Databases Health Check\": ...}"`