### PR TITLE
Better file exists check

### DIFF
--- a/healthcheck/healthcheck.py
+++ b/healthcheck/healthcheck.py
@@ -1,6 +1,4 @@
 import abc
-import errno
-import os
 import utils
 
 

--- a/healthcheck/healthcheck.py
+++ b/healthcheck/healthcheck.py
@@ -185,11 +185,12 @@ class HealthChecker(object):
 
 
 def _file_exists(path):
-    """Returns True if a file exists at `path` (even if it can't be read),
+    """Return True if a file exists at `path` (even if it can't be read),
     otherwise False.
 
     This is different from os.path.isfile and os.path.exists which return
-    False if a file exists but the user doesn't have permission to read it."""
+    False if a file exists but the user doesn't have permission to read it.
+    """
     try:
         os.stat(path)
         return True

--- a/healthcheck/healthcheck.py
+++ b/healthcheck/healthcheck.py
@@ -1,6 +1,7 @@
 import abc
 import errno
 import os
+import utils
 
 
 class HealthCheck(object):
@@ -117,7 +118,7 @@ class FilesExistHealthCheck(ListHealthCheck):
     """Fails if at least one of passed files doesn't exist."""
 
     def check_item(self, filename):
-        file_exists = _file_exists(filename)
+        file_exists = utils.file_exists(filename)
         details = {filename: 'exists' if file_exists else 'NO SUCH FILE'}
         return file_exists, details
 
@@ -126,7 +127,7 @@ class FilesDontExistHealthCheck(ListHealthCheck):
     """Fails if at least one of passed files exists."""
 
     def check_item(self, filename):
-        file_exists = _file_exists(filename)
+        file_exists = utils.file_exists(filename)
         details = {filename: 'FILE EXISTS' if file_exists else 'no such file'}
         return not file_exists, details
 
@@ -182,27 +183,3 @@ class HealthChecker(object):
             return False
 
         return True
-
-
-def _file_exists(path):
-    """Return True if a file exists at `path` (even if it can't be read),
-    otherwise False.
-
-    This is different from os.path.isfile and os.path.exists which return
-    False if a file exists but the user doesn't have permission to read it.
-    """
-    try:
-        os.stat(path)
-        return True
-    except OSError as e:
-
-        # Permission denied: someone chose the wrong permissions but it exists
-        if e.errno == errno.EACCES:
-            return True
-
-        # File doesn't exist
-        elif e.errno == errno.ENOENT:
-            return False
-
-        # Unknown case
-        raise

--- a/healthcheck/healthcheck.py
+++ b/healthcheck/healthcheck.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import abc
-import utils
+from healthcheck.utils import file_exists
 
 
 class HealthCheck(object):
@@ -116,18 +117,30 @@ class FilesExistHealthCheck(ListHealthCheck):
     """Fails if at least one of passed files doesn't exist."""
 
     def check_item(self, filename):
-        file_exists = utils.file_exists(filename)
-        details = {filename: 'exists' if file_exists else 'NO SUCH FILE'}
-        return file_exists, details
+        try:
+            ok = file_exists(filename)
+        except OSError as e:
+            ok = False
+            description = 'ERROR: ' + str(e.strerror)
+        else:
+            description = 'exists' if ok else 'NO SUCH FILE'
+        details = {filename: description}
+        return ok, details
 
 
 class FilesDontExistHealthCheck(ListHealthCheck):
     """Fails if at least one of passed files exists."""
 
     def check_item(self, filename):
-        file_exists = utils.file_exists(filename)
-        details = {filename: 'FILE EXISTS' if file_exists else 'no such file'}
-        return not file_exists, details
+        try:
+            ok = not file_exists(filename)
+        except OSError as e:
+            ok = False
+            description = 'ERROR: ' + str(e.strerror)
+        else:
+            description = 'no such file' if ok else 'FILE EXISTS'
+        details = {filename: description}
+        return ok, details
 
 
 class HealthChecker(object):

--- a/healthcheck/healthcheck.py
+++ b/healthcheck/healthcheck.py
@@ -204,5 +204,5 @@ def _file_exists(path):
         elif e.errno == errno.ENOENT:
             return False
 
-        # Unkown case
+        # Unknown case
         raise

--- a/healthcheck/utils.py
+++ b/healthcheck/utils.py
@@ -3,24 +3,18 @@ import os
 
 
 def file_exists(path):
-    """Return True if a file exists at `path` (even if it can't be read),
-    otherwise False.
+    """Return True if a file exists at `path`, False if it definitely
+    doesn't.
 
-    This is different from os.path.isfile and os.path.exists which return
-    False if a file exists but the user doesn't have permission to read it.
+    If some other error occurs when trying to see the file this will be
+    raised. In particular it will raise an error if it doesn't have
+    permission to list the file, whereas os.path.isfile and
+    os.path.exists would simply return False.
     """
     try:
         os.stat(path)
         return True
     except OSError as e:
-
-        # Permission denied: someone chose the wrong permissions but it exists.
-        if e.errno == errno.EACCES:
-            return True
-
-        # File doesn't exist
-        elif e.errno == errno.ENOENT:
+        if e.errno == errno.ENOENT:
             return False
-
-        # Unknown case
         raise

--- a/healthcheck/utils.py
+++ b/healthcheck/utils.py
@@ -14,7 +14,7 @@ def file_exists(path):
         return True
     except OSError as e:
 
-        # Permission denied: someone chose the wrong permissions but it exists
+        # Permission denied: someone chose the wrong permissions but it exists.
         if e.errno == errno.EACCES:
             return True
 

--- a/healthcheck/utils.py
+++ b/healthcheck/utils.py
@@ -1,0 +1,26 @@
+import errno
+import os
+
+
+def file_exists(path):
+    """Return True if a file exists at `path` (even if it can't be read),
+    otherwise False.
+
+    This is different from os.path.isfile and os.path.exists which return
+    False if a file exists but the user doesn't have permission to read it.
+    """
+    try:
+        os.stat(path)
+        return True
+    except OSError as e:
+
+        # Permission denied: someone chose the wrong permissions but it exists
+        if e.errno == errno.EACCES:
+            return True
+
+        # File doesn't exist
+        elif e.errno == errno.ENOENT:
+            return False
+
+        # Unknown case
+        raise

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -140,7 +140,7 @@ class TestFilesExistHealthCheck(TestCase):
         self.assertEqual(check.details, {file1: 'exists',
                                          file2: 'exists'})
 
-    def test_ok_if_at_least_one_file_doesnt_exist(self):
+    def test_not_ok_if_at_least_one_file_doesnt_exist(self):
         tmpfile1 = NamedTemporaryFile()
         file1 = tmpfile1.name
         check = FilesExistHealthCheck((file1, 'file2'), check_id='checkid')
@@ -151,7 +151,7 @@ class TestFilesExistHealthCheck(TestCase):
 
 
 class TestFilesDontExistHealthCheck(TestCase):
-    def test_ok_if_all_files_exist(self):
+    def test_ok_if_all_files_dont_exist(self):
         check = FilesDontExistHealthCheck(('file1', 'file2'),
                                           check_id='checkid')
         check.run()
@@ -159,7 +159,7 @@ class TestFilesDontExistHealthCheck(TestCase):
         self.assertEqual(check.details, {'file1': 'no such file',
                                          'file2': 'no such file'})
 
-    def test_ok_if_at_least_one_file_doesnt_exist(self):
+    def test_not_ok_if_at_least_one_file_exists(self):
         tmpfile2 = NamedTemporaryFile()
         file2 = tmpfile2.name
         check = FilesDontExistHealthCheck(('file1', file2),

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -152,20 +152,12 @@ class TestFilesExistHealthCheck(TestCase):
 
     @patch('os.stat')
     def test_ok_if_file_exists_with_wrong_permissions(self, stat_mock):
-        def permission_denied_stat(_):
-            err = OSError()
-            err.errno = errno.EACCES
-            raise err
-        stat_mock.side_effect = permission_denied_stat
+        stat_mock.side_effect = OSError(errno.EACCES, 'Permission denied')
         self.test_ok_if_all_files_exist()
 
     @patch('os.stat')
     def test_error_if_unknown_exception_occurs(self, stat_mock):
-        def permission_denied_stat(_):
-            err = OSError()
-            err.errno = 99999  # i.e. an unknown error
-            raise err
-        stat_mock.side_effect = permission_denied_stat
+        stat_mock.side_effect = OSError(9999, 'Unknown error')
         with self.assertRaises(OSError):
             self.test_ok_if_all_files_exist()
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -153,13 +153,10 @@ class TestFilesExistHealthCheck(TestCase):
     @patch('os.stat')
     def test_ok_if_file_exists_with_wrong_permissions(self, stat_mock):
         stat_mock.side_effect = OSError(errno.EACCES, 'Permission denied')
-        self.test_ok_if_all_files_exist()
-
-    @patch('os.stat')
-    def test_error_if_unknown_exception_occurs(self, stat_mock):
-        stat_mock.side_effect = OSError(9999, 'Unknown error')
-        with self.assertRaises(OSError):
-            self.test_ok_if_all_files_exist()
+        check = FilesExistHealthCheck(('file',), check_id='checkid')
+        check.run()
+        self.assertFalse(check.is_ok)
+        self.assertEqual(check.details, {'file': 'ERROR: Permission denied'})
 
 
 class TestFilesDontExistHealthCheck(TestCase):

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -179,7 +179,8 @@ class TestFilesHealthCheckWithError(TestCase):
             check = check_type(('file',), check_id='checkid')
             check.run()
             self.assertFalse(check.is_ok)
-            self.assertEqual(check.details, {'file': 'ERROR: Permission denied'})
+            self.assertEqual(check.details,
+                             {'file': 'ERROR: Permission denied'})
 
 
 class TestHealthChecker(TestCase):


### PR DESCRIPTION
Previously if someone created a quiesce file with the wrong permissions the check wouldn't pick it up and nothing would change. This PR uses a more general test to see if a file exists to fix that problem. It also generalises the tests to create actual temporary files since the current tests used mocks which were too restrictive and couldn't handle the new method.