### PR TITLE
Expand supported Django version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage == 3.7.1
-django>=1.4,< 1.7
+django>=1.4,< 1.12
 mock<1.2.0
 nose<2.0.0
 python-coveralls==2.5.0


### PR DESCRIPTION
I don't see any reason of having it < 1.7 here.