### PR TITLE
Added catching OperationalError exception for django dbs check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [Changelog](https://github.com/yola/healthcheck)
 
 ## 0.1.2
-* Added cathing OperationalError exception for django dbs check.
+* Added catching OperationalError exception for django dbs check.
 
 ## 0.1.0
 * Removed Python 2.6 support, added Python 3.5 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/healthcheck)
 
+## 0.1.2
+* Added cathing OperationalError exception for django dbs check.
+
 ## 0.1.0
 * Removed Python 2.6 support, added Python 3.5 support.
 

--- a/healthcheck/__init__.py
+++ b/healthcheck/__init__.py
@@ -1,5 +1,5 @@
 __doc__ = 'Health Checker for Yola Services'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __url__ = 'https://github.com/yola/healthcheck'
 
 from .checks import (DjangoDBsHealthCheck, FilesDontExistHealthCheck,

--- a/healthcheck/checks.py
+++ b/healthcheck/checks.py
@@ -104,9 +104,10 @@ class DjangoDBsHealthCheck(ListHealthCheck):
         from django.db.utils import OperationalError
         try:
             connection.ensure_connection()
-            db_ok = connection.is_usable()
         except OperationalError:
             db_ok = False
+        else:
+            db_ok = connection.is_usable()
         details = {connection.alias: 'ok' if db_ok else 'FAILED'}
         return db_ok, details
 

--- a/healthcheck/checks.py
+++ b/healthcheck/checks.py
@@ -101,8 +101,12 @@ class DjangoDBsHealthCheck(ListHealthCheck):
         return connections.all()
 
     def check_item(self, connection):
-        connection.ensure_connection()
-        db_ok = connection.is_usable()
+        from django.db.utils import OperationalError
+        try:
+            connection.ensure_connection()
+            db_ok = connection.is_usable()
+        except OperationalError:
+            db_ok = False
         details = {connection.alias: 'ok' if db_ok else 'FAILED'}
         return db_ok, details
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-coverage==3.7.1
-django==1.11
-mock==1.1.0
-nose==1.3.7
-python-coveralls==2.5.0
+Django == 1.11.20
+coverage == 3.7.1
+mock == 2.0.0
+nose == 1.3.7
+python-coveralls == 2.9.1
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -202,7 +202,6 @@ class TestDjangoDBsHealthCheck(TestCase):
         connection_mock.ensure_connection.assert_called_once_with()
         connection_mock.is_usable.assert_called_once_with()
 
-
     @patch('django.db.connections')
     def test_fails_when_ensure_connection_fail(self, connections_mock):
         connections_mock.all.return_value = [

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -193,11 +193,15 @@ class TestDjangoDBsHealthCheck(TestCase):
 
     @patch('django.db.connections')
     def test_returns_ok(self, connections_mock):
-        connections_mock.all.return_value = [Mock(alias='db_name')]
+        connection_mock = Mock(alias='db_name')
+        connections_mock.all.return_value = [connection_mock]
         check = DjangoDBsHealthCheck()
         check.run()
         self.assertTrue(check.is_ok)
         self.assertEqual(check.details, {'db_name': 'ok'})
+        connection_mock.ensure_connection.assert_called_once_with()
+        connection_mock.is_usable.assert_called_once_with()
+
 
     @patch('django.db.connections')
     def test_fails_when_ensure_connection_fail(self, connections_mock):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -3,11 +3,17 @@ import errno
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-from mock import patch
+from django.db import OperationalError
+from mock import Mock, patch
 
 from healthcheck.checks import (
-    FilesDontExistHealthCheck, FilesExistHealthCheck,
-    HealthCheck, HealthChecker, ListHealthCheck)
+    DjangoDBsHealthCheck,
+    FilesDontExistHealthCheck,
+    FilesExistHealthCheck,
+    HealthCheck,
+    HealthChecker,
+    ListHealthCheck,
+)
 
 
 class MyCheck(HealthCheck):
@@ -181,6 +187,39 @@ class TestFilesHealthCheckWithError(TestCase):
             self.assertFalse(check.is_ok)
             self.assertEqual(check.details,
                              {'file': 'ERROR: Permission denied'})
+
+
+class TestDjangoDBsHealthCheck(TestCase):
+
+    @patch('django.db.connections')
+    def test_returns_ok(self, connections_mock):
+        connections_mock.all.return_value = [Mock(alias='db_name')]
+        check = DjangoDBsHealthCheck()
+        check.run()
+        self.assertTrue(check.is_ok)
+        self.assertEqual(check.details, {'db_name': 'ok'})
+
+    @patch('django.db.connections')
+    def test_fails_when_ensure_connection_fail(self, connections_mock):
+        connections_mock.all.return_value = [
+            Mock(alias='db_name',
+                 ensure_connection=Mock(side_effect=OperationalError()))
+        ]
+        check = DjangoDBsHealthCheck()
+        check.run()
+        self.assertFalse(check.is_ok)
+        self.assertEqual(check.details, {'db_name': 'FAILED'})
+
+    @patch('django.db.connections')
+    def test_fails_when_connection_is_not_usable(self, connections_mock):
+        connections_mock.all.return_value = [
+            Mock(alias='db_name',
+                 is_usable=Mock(return_value=False))
+        ]
+        check = DjangoDBsHealthCheck()
+        check.run()
+        self.assertFalse(check.is_ok)
+        self.assertEqual(check.details, {'db_name': 'FAILED'})
 
 
 class TestHealthChecker(TestCase):


### PR DESCRIPTION
Tested locally with postgresql and mysql, when db was stopped, `/status/` endpoint returned 500 error with `OperationalError`