### PR TITLE
Thread-safe DB connections (with tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,22 @@ language: python
 python:
    - "2.7"
    - "3.4"
+services:
+   - mysql
+   - postgresql
+before_install:
+   - "sudo apt-get install -y libmysqlclient-dev libpq-dev"
+   - "mysqladmin create test"
+env:
+   global:
+      - MYSQL_HOST=localhost
+      - PGHOST=localhost
+      - PGPORT=5432
+      - PGDATABASE=postgres
+      - PGUSER=postgres
+      - PGPASSWORD=
 install: "pip install -r requirements.txt"
 script:
    - "nosetests --with-coverage --cover-package=healthcheck"
 after_success:
-    - coveralls
+   - coveralls

--- a/README.md
+++ b/README.md
@@ -98,3 +98,10 @@ Running Tests
 -------------
 
 `cd healthcheck; python setup.py test`
+
+If you have PostgreSQL available, you can test against a postgres DB, with
+`pg_virtualenv`.
+
+If you have MySQL available, you can test against a MySQL DB, with
+`my_virtualenv`, or export `MYSQL_HOST=localhost`. It requires a
+database named "test" to exist.

--- a/healthcheck/checks.py
+++ b/healthcheck/checks.py
@@ -66,14 +66,14 @@ class ListHealthCheck(HealthCheck):
         if not items and not self.items:
             raise ValueError('You have to specify items inside class or '
                              'pass items list on object construction')
+        self.kwarg_items = items
 
-        self._items = items if items is not None else self.items
 
     def run(self):
         self._ok = True
         self._details = {}
 
-        for item in self._items:
+        for item in self.kwarg_items or self.items:
             item_ok, item_details = self.check_item(item)
             if not item_ok:
                 self._ok = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 coverage==3.7.1
 django==1.11
 mock==1.1.0
+mysqlclient==1.3.14
 nose==1.3.7
+psycopg2==2.7.7
 python-coveralls==2.5.0
-

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,3 +1,5 @@
+import os
+
 SECRET_KEY = 'None'
 ROOT_URLCONF = 'healthcheck.contrib.django.status_endpoint.urls'
 
@@ -5,5 +7,24 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': 'mydatabase',
-    }
+    },
 }
+
+# pg_virtualenv:
+if 'PGHOST' in os.environ:
+    DATABASES['postgres'] = {
+        'ENGINE': 'django.db.backends.postgresql',
+        'HOST': os.environ['PGHOST'],
+        'PORT': os.environ['PGPORT'],
+        'NAME': os.environ['PGDATABASE'],
+        'USER': os.environ['PGUSER'],
+        'PASSWORD': os.environ['PGPASSWORD'],
+    }
+
+# my_virtualenv:
+if 'MYSQL_HOST' in os.environ:
+    DATABASES['mysql'] = {
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': os.environ['MYSQL_HOST'],
+        'NAME': 'test',
+    }


### PR DESCRIPTION
I don't know if the first 2 commits of this are something we want to merge or not. They were useful for demonstrating the bug was fixed, but are fairly specific to the details of the bug.

DjangoDBsHealthCheck assumes that .items() will be called from the same thread that calls .run(). The return value from `django.db.connections` includes thread-local variables.

By evaluating `.items()` once at instantiation, there's no guarantee that we won't try to access these variables from the wrong threads.

I'm somewhat tempted to just merge the fix on its own, so I filed a separate PR like that: #26
